### PR TITLE
Implement dataWindowNDC (crop rendering) support

### DIFF
--- a/hdmitsuba/render_pass.cc
+++ b/hdmitsuba/render_pass.cc
@@ -19,6 +19,8 @@
 #include <pxr/imaging/hd/aov.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/renderPass.h>
+#include <optional>
+#include <pxr/imaging/cameraUtil/framing.h>
 #include <pxr/imaging/hd/renderPassState.h>
 #include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/pxr.h>
@@ -48,7 +50,11 @@ void HdMitsubaRenderPass::_Execute(
     scene_manager_->SetAovBindings(this, aov_bindings);
     aov_bindings_ = aov_bindings;
   }
-  scene_manager_->Render(this, renderPassState->GetCamera());
+  std::optional<GfRect2i> crop_window;
+  if (renderPassState->GetFraming().IsValid()) {
+    crop_window = renderPassState->GetFraming().dataWindow;
+  }
+  scene_manager_->Render(this, renderPassState->GetCamera(), crop_window);
 }
 
 bool HdMitsubaRenderPass::IsConverged() const {

--- a/hdmitsuba/scene_manager.cc
+++ b/hdmitsuba/scene_manager.cc
@@ -884,7 +884,7 @@ class SceneModel final : public SceneManager {
 
     if (film_changed) {
       sensor->parameters_changed();
-      if (frozen_render_) frozen_render_->Clear();
+      if (frozen_render_) frozen_render_->Clear(); // Invalidate cache on resize
     }
 
     if (!integrator_) {

--- a/hdmitsuba/scene_manager.cc
+++ b/hdmitsuba/scene_manager.cc
@@ -195,28 +195,31 @@ void ScalarCopyToRenderBuffer(HdMitsubaRenderBuffer* render_buffer,
   size_t src_channels = tensor.shape()[2];
   void* dst_ptr = render_buffer->Map();
 
-  size_t crop_x = crop_window.has_value() ? crop_window->GetMinX() : 0;
-  size_t crop_y = crop_window.has_value() ? crop_window->GetMinY() : 0;
-  size_t crop_w = crop_window.has_value() ? crop_window->GetWidth() : dst_width;
-  size_t crop_h = crop_window.has_value() ? crop_window->GetHeight() : dst_height;
+  size_t crop_x = 0;
+  size_t crop_y = 0;
+  size_t crop_w = dst_width;
+  size_t crop_h = dst_height;
+  if (crop_window.has_value()) {
+    crop_x = crop_window->GetMinX();
+    crop_y = crop_window->GetMinY();
+    crop_w = crop_window->GetWidth();
+    crop_h = crop_window->GetHeight();
+  }
 
   if (crop_w != tensor.shape()[1] || crop_h != tensor.shape()[0]) {
-    TF_RUNTIME_ERROR(
+    TF_FATAL_ERROR(
         "Tensor dimensions do not match crop window: %lu x %lu vs %lu x %lu",
         crop_w, crop_h, tensor.shape()[1], tensor.shape()[0]);
-    render_buffer->Unmap();
-    return;
   }
 
   const float* src_data = tensor.array().data();
   if (is_int) {
     int32_t* dst_int = static_cast<int32_t*>(dst_ptr);
-    for (size_t y = 0; y < crop_h; ++y) {
-      size_t src_y = crop_h - 1 - y;  // Flip vertically.
-      size_t dst_y = (dst_height - crop_y - crop_h) + y; // Map to Y-up destination.
-      for (size_t x = 0; x < crop_w; ++x) {
-        size_t src_idx = (src_y * crop_w + x) * src_channels + src_offset;
-        size_t dst_idx = (dst_y * dst_width + (crop_x + x)) * dst_channels;
+    for (size_t src_y = 0; src_y < crop_h; ++src_y) {
+      size_t dst_y = (dst_height - 1) - (crop_y + src_y);
+      for (size_t src_x = 0; src_x < crop_w; ++src_x) {
+        size_t src_idx = (src_y * crop_w + src_x) * src_channels + src_offset;
+        size_t dst_idx = (dst_y * dst_width + (crop_x + src_x)) * dst_channels;
         for (int c = 0; c < channels && c < dst_channels; ++c) {
           dst_int[dst_idx + c] = static_cast<int32_t>(src_data[src_idx + c]);
         }
@@ -224,12 +227,11 @@ void ScalarCopyToRenderBuffer(HdMitsubaRenderBuffer* render_buffer,
     }
   } else {
     float* dst_float = static_cast<float*>(dst_ptr);
-    for (size_t y = 0; y < crop_h; ++y) {
-      size_t src_y = crop_h - 1 - y;  // Flip vertically.
-      size_t dst_y = (dst_height - crop_y - crop_h) + y; // Map to Y-up destination.
-      for (size_t x = 0; x < crop_w; ++x) {
-        size_t src_idx = (src_y * crop_w + x) * src_channels + src_offset;
-        size_t dst_idx = (dst_y * dst_width + (crop_x + x)) * dst_channels;
+    for (size_t src_y = 0; src_y < crop_h; ++src_y) {
+      size_t dst_y = (dst_height - 1) - (crop_y + src_y);
+      for (size_t src_x = 0; src_x < crop_w; ++src_x) {
+        size_t src_idx = (src_y * crop_w + src_x) * src_channels + src_offset;
+        size_t dst_idx = (dst_y * dst_width + (crop_x + src_x)) * dst_channels;
         for (int c = 0; c < channels && c < dst_channels; ++c) {
           dst_float[dst_idx + c] = src_data[src_idx + c];
         }
@@ -269,34 +271,65 @@ void PerformBatchedCopy(const TensorT& tensor,
     for (const auto& dest : destinations) {
       int dst_channels = HdGetComponentCount(dest.buffer->GetFormat());
       using UInt32 = dr::uint32_array_t<Float>;
-      size_t height = tensor.shape()[0];
-      size_t width = tensor.shape()[1];
-      size_t pixel_count = width * height;
+      size_t dst_width = dest.buffer->GetWidth();
+      size_t dst_height = dest.buffer->GetHeight();
+      size_t dst_pixel_count = dst_width * dst_height;
 
-      UInt32 pixel_idx = dr::arange<UInt32>(pixel_count);
-      UInt32 x = pixel_idx % width;
-      UInt32 y = height - 1 - pixel_idx / width;
-      UInt32 repeated_pixel_idx = dr::repeat(y * width + x, dst_channels);
-      UInt32 channel_offsets =
-          dr::tile(dr::arange<UInt32>(dst_channels), pixel_count);
-      UInt32 final_idx = repeated_pixel_idx * tensor.shape()[2] +
-                         dest.src_offset + channel_offsets;
-      Float gathered;
-      if (dst_channels == 4 && dest.channels == 3) {
-        gathered =
-            dr::select(channel_offsets < 3,
-                       dr::gather<Float>(tensor.array(), final_idx), 1.0f);
-      } else {
-        gathered = dr::gather<Float>(tensor.array(), final_idx);
+      size_t crop_x = 0;
+      size_t crop_y = 0;
+      size_t crop_w = dst_width;
+      size_t crop_h = dst_height;
+      if (crop_window.has_value()) {
+        crop_x = crop_window->GetMinX();
+        crop_y = crop_window->GetMinY();
+        crop_w = crop_window->GetWidth();
+        crop_h = crop_window->GetHeight();
       }
 
+      UInt32 dst_pixel_idx = dr::arange<UInt32>(dst_pixel_count);
+      UInt32 dst_x = dst_pixel_idx % dst_width;
+      UInt32 dst_row = dst_pixel_idx / dst_width;
+      UInt32 r_topdown = dst_height - 1 - dst_row;
+
+      auto in_crop = (dst_x >= crop_x) && (dst_x < crop_x + crop_w) &&
+                     (r_topdown >= crop_y) && (r_topdown < crop_y + crop_h);
+
+      UInt32 src_x = dst_x - crop_x;
+      UInt32 src_y_down = r_topdown - crop_y;
+      UInt32 src_pixel_idx =
+          dr::select(in_crop, src_y_down * crop_w + src_x, 0);
+
+      UInt32 repeated_pixel_idx =
+          dr::repeat(src_pixel_idx, dst_channels);
+      UInt32 channel_offsets =
+          dr::tile(dr::arange<UInt32>(dst_channels), dst_pixel_count);
+      UInt32 final_idx = repeated_pixel_idx * tensor.shape()[2] +
+                         dest.src_offset + channel_offsets;
+
+      auto in_crop_channel = dr::repeat(in_crop, dst_channels);
+
       if (dest.is_int) {
-        Int32 int_data = Int32(gathered);
-        dr::schedule(int_data);
-        gathered_vars.push_back(int_data);
+        Int32 gathered_int = dr::select(
+            in_crop_channel,
+            Int32(dr::gather<Float>(tensor.array(), final_idx)),
+            0);
+        dr::schedule(gathered_int);
+        gathered_vars.push_back(gathered_int);
       } else {
-        dr::schedule(gathered);
-        gathered_vars.push_back(gathered);
+        Float gathered_float;
+        if (dst_channels == 4 && dest.channels == 3) {
+          gathered_float = dr::select(
+              in_crop_channel,
+              dr::select(channel_offsets < 3,
+                         dr::gather<Float>(tensor.array(), final_idx), 1.0f),
+              0.0f);
+        } else {
+          gathered_float = dr::select(
+              in_crop_channel,
+              dr::gather<Float>(tensor.array(), final_idx), 0.0f);
+        }
+        dr::schedule(gathered_float);
+        gathered_vars.push_back(gathered_float);
       }
     }
     dr::eval();
@@ -319,24 +352,12 @@ void PerformBatchedCopy(const TensorT& tensor,
       int dst_channels = HdGetComponentCount(dest.buffer->GetFormat());
       size_t dst_width = dest.buffer->GetWidth();
       size_t dst_height = dest.buffer->GetHeight();
-
-      size_t crop_x = crop_window.has_value() ? crop_window->GetMinX() : 0;
-      size_t crop_y = crop_window.has_value() ? crop_window->GetMinY() : 0;
-      size_t crop_w = crop_window.has_value() ? crop_window->GetWidth() : dst_width;
-      size_t crop_h = crop_window.has_value() ? crop_window->GetHeight() : dst_height;
-
       size_t element_size = dest.is_int ? sizeof(int32_t) : sizeof(float);
-      size_t row_size_bytes = crop_w * dst_channels * element_size;
+      size_t size_bytes = dst_width * dst_height * dst_channels * element_size;
+
       std::visit(
           [&](auto& host_arr) {
-            const char* src_ptr = reinterpret_cast<const char*>(host_arr.data());
-            char* dst_char = reinterpret_cast<char*>(dst_ptr);
-            for (size_t y = 0; y < crop_h; ++y) {
-              size_t dst_y = (dst_height - crop_y - crop_h) + y;
-              size_t dst_offset = (dst_y * dst_width + crop_x) * dst_channels * element_size;
-              size_t src_offset = (y * crop_w) * dst_channels * element_size;
-              memcpy(dst_char + dst_offset, src_ptr + src_offset, row_size_bytes);
-            }
+            memcpy(dst_ptr, host_arr.data(), size_bytes);
           },
           migrated_vars[i]);
       dest.buffer->SetConverged(true);
@@ -847,7 +868,6 @@ class SceneModel final : public SceneManager {
     if (film_size.x() != buffer_width || film_size.y() != buffer_height) {
       film->set_size(ScalarPoint2u(buffer_width, buffer_height));
       film_changed = true;
-      if (frozen_render_) frozen_render_->Clear(); // Invalidate cache on resize
     }
 
     ScalarPoint2u new_crop_offset(0, 0);
@@ -864,6 +884,7 @@ class SceneModel final : public SceneManager {
 
     if (film_changed) {
       sensor->parameters_changed();
+      if (frozen_render_) frozen_render_->Clear();
     }
 
     if (!integrator_) {

--- a/hdmitsuba/scene_manager.cc
+++ b/hdmitsuba/scene_manager.cc
@@ -177,7 +177,8 @@ struct JitScopeGuard {
 template <typename TensorT>
 void ScalarCopyToRenderBuffer(HdMitsubaRenderBuffer* render_buffer,
                               const TensorT& tensor, int src_offset, int channels,
-                              bool is_int) {
+                              bool is_int,
+                              const std::optional<GfRect2i>& crop_window = std::nullopt) {
   if (!TF_VERIFY(render_buffer, "Render buffer is null.")) {
     return;
   }
@@ -189,19 +190,33 @@ void ScalarCopyToRenderBuffer(HdMitsubaRenderBuffer* render_buffer,
     return;
   }
 
-  size_t height = tensor.shape()[0];
-  size_t width = tensor.shape()[1];
+  size_t dst_width = render_buffer->GetWidth();
+  size_t dst_height = render_buffer->GetHeight();
   size_t src_channels = tensor.shape()[2];
   void* dst_ptr = render_buffer->Map();
+
+  size_t crop_x = crop_window.has_value() ? crop_window->GetMinX() : 0;
+  size_t crop_y = crop_window.has_value() ? crop_window->GetMinY() : 0;
+  size_t crop_w = crop_window.has_value() ? crop_window->GetWidth() : dst_width;
+  size_t crop_h = crop_window.has_value() ? crop_window->GetHeight() : dst_height;
+
+  if (crop_w != tensor.shape()[1] || crop_h != tensor.shape()[0]) {
+    TF_RUNTIME_ERROR(
+        "Tensor dimensions do not match crop window: %lu x %lu vs %lu x %lu",
+        crop_w, crop_h, tensor.shape()[1], tensor.shape()[0]);
+    render_buffer->Unmap();
+    return;
+  }
 
   const float* src_data = tensor.array().data();
   if (is_int) {
     int32_t* dst_int = static_cast<int32_t*>(dst_ptr);
-    for (size_t y = 0; y < height; ++y) {
-      size_t src_y = height - 1 - y;  // Flip vertically.
-      for (size_t x = 0; x < width; ++x) {
-        size_t src_idx = (src_y * width + x) * src_channels + src_offset;
-        size_t dst_idx = (y * width + x) * dst_channels;
+    for (size_t y = 0; y < crop_h; ++y) {
+      size_t src_y = crop_h - 1 - y;  // Flip vertically.
+      size_t dst_y = (dst_height - crop_y - crop_h) + y; // Map to Y-up destination.
+      for (size_t x = 0; x < crop_w; ++x) {
+        size_t src_idx = (src_y * crop_w + x) * src_channels + src_offset;
+        size_t dst_idx = (dst_y * dst_width + (crop_x + x)) * dst_channels;
         for (int c = 0; c < channels && c < dst_channels; ++c) {
           dst_int[dst_idx + c] = static_cast<int32_t>(src_data[src_idx + c]);
         }
@@ -209,11 +224,12 @@ void ScalarCopyToRenderBuffer(HdMitsubaRenderBuffer* render_buffer,
     }
   } else {
     float* dst_float = static_cast<float*>(dst_ptr);
-    for (size_t y = 0; y < height; ++y) {
-      size_t src_y = height - 1 - y;  // Flip vertically.
-      for (size_t x = 0; x < width; ++x) {
-        size_t src_idx = (src_y * width + x) * src_channels + src_offset;
-        size_t dst_idx = (y * width + x) * dst_channels;
+    for (size_t y = 0; y < crop_h; ++y) {
+      size_t src_y = crop_h - 1 - y;  // Flip vertically.
+      size_t dst_y = (dst_height - crop_y - crop_h) + y; // Map to Y-up destination.
+      for (size_t x = 0; x < crop_w; ++x) {
+        size_t src_idx = (src_y * crop_w + x) * src_channels + src_offset;
+        size_t dst_idx = (dst_y * dst_width + (crop_x + x)) * dst_channels;
         for (int c = 0; c < channels && c < dst_channels; ++c) {
           dst_float[dst_idx + c] = src_data[src_idx + c];
         }
@@ -239,7 +255,8 @@ struct CopyDestination {
 // buffers.
 template <typename Float, typename TensorT>
 void PerformBatchedCopy(const TensorT& tensor,
-                        const std::vector<CopyDestination>& destinations) {
+                        const std::vector<CopyDestination>& destinations,
+                        const std::optional<GfRect2i>& crop_window = std::nullopt) {
   if constexpr (dr::is_jit_v<Float>) {
     using Int32 = dr::int32_array_t<Float>;
     using MigratedFloat = std::decay_t<decltype(dr::migrate(
@@ -300,10 +317,27 @@ void PerformBatchedCopy(const TensorT& tensor,
       const auto& dest = destinations[i];
       void* dst_ptr = dest.buffer->Map();
       int dst_channels = HdGetComponentCount(dest.buffer->GetFormat());
-      size_t size_bytes = tensor.shape()[0] * tensor.shape()[1] * dst_channels *
-                          (dest.is_int ? sizeof(int32_t) : sizeof(float));
+      size_t dst_width = dest.buffer->GetWidth();
+      size_t dst_height = dest.buffer->GetHeight();
+
+      size_t crop_x = crop_window.has_value() ? crop_window->GetMinX() : 0;
+      size_t crop_y = crop_window.has_value() ? crop_window->GetMinY() : 0;
+      size_t crop_w = crop_window.has_value() ? crop_window->GetWidth() : dst_width;
+      size_t crop_h = crop_window.has_value() ? crop_window->GetHeight() : dst_height;
+
+      size_t element_size = dest.is_int ? sizeof(int32_t) : sizeof(float);
+      size_t row_size_bytes = crop_w * dst_channels * element_size;
       std::visit(
-          [&](auto& host_arr) { memcpy(dst_ptr, host_arr.data(), size_bytes); },
+          [&](auto& host_arr) {
+            const char* src_ptr = reinterpret_cast<const char*>(host_arr.data());
+            char* dst_char = reinterpret_cast<char*>(dst_ptr);
+            for (size_t y = 0; y < crop_h; ++y) {
+              size_t dst_y = (dst_height - crop_y - crop_h) + y;
+              size_t dst_offset = (dst_y * dst_width + crop_x) * dst_channels * element_size;
+              size_t src_offset = (y * crop_w) * dst_channels * element_size;
+              memcpy(dst_char + dst_offset, src_ptr + src_offset, row_size_bytes);
+            }
+          },
           migrated_vars[i]);
       dest.buffer->SetConverged(true);
       dest.buffer->Unmap();
@@ -311,7 +345,7 @@ void PerformBatchedCopy(const TensorT& tensor,
   } else {
     for (const auto& dest : destinations) {
       ScalarCopyToRenderBuffer(dest.buffer, tensor, dest.src_offset,
-                               dest.channels, dest.is_int);
+                               dest.channels, dest.is_int, crop_window);
     }
   }
 }
@@ -756,7 +790,8 @@ class SceneModel final : public SceneManager {
   }
 
   void Render(const HdRenderPass* render_pass,
-              const HdCamera* camera) override {
+              const HdCamera* camera,
+              const std::optional<GfRect2i>& crop_window = std::nullopt) override {
     absl::MutexLock state_lock(state_mutex_);
     absl::MutexLock aov_lock(aov_states_mutex_);
     JitScopeGuard<Float> jit_guard;
@@ -807,11 +842,28 @@ class SceneModel final : public SceneManager {
 
     Film* film = sensor->film();
     auto film_size = film->size();
+    bool film_changed = false;
     // If necessary, resize film to match USD buffer size.
     if (film_size.x() != buffer_width || film_size.y() != buffer_height) {
       film->set_size(ScalarPoint2u(buffer_width, buffer_height));
-      sensor->parameters_changed();
+      film_changed = true;
       if (frozen_render_) frozen_render_->Clear(); // Invalidate cache on resize
+    }
+
+    ScalarPoint2u new_crop_offset(0, 0);
+    ScalarVector2u new_crop_size = film->size();
+    if (crop_window.has_value()) {
+      new_crop_offset = ScalarPoint2u(crop_window->GetMinX(), crop_window->GetMinY());
+      new_crop_size = ScalarVector2u(crop_window->GetWidth(), crop_window->GetHeight());
+    }
+
+    if (dr::any(film->crop_offset() != new_crop_offset) || dr::any(film->crop_size() != new_crop_size)) {
+      film->set_crop_window(new_crop_offset, new_crop_size);
+      film_changed = true;
+    }
+
+    if (film_changed) {
+      sensor->parameters_changed();
     }
 
     if (!integrator_) {
@@ -865,10 +917,12 @@ class SceneModel final : public SceneManager {
           if (frozen_render_) frozen_render_->Clear(); // Clear cache if freezing is disabled
         }
       }
-      if (static_cast<size_t>(buffer_width) != result.shape()[1] ||
-          static_cast<size_t>(buffer_height) != result.shape()[0]) {
-        TF_RUNTIME_ERROR("Buffer size mismatch: %u x %u vs %lu x %lu",
-                         buffer_width, buffer_height, result.shape()[1],
+      size_t expected_width = crop_window.has_value() ? crop_window->GetWidth() : buffer_width;
+      size_t expected_height = crop_window.has_value() ? crop_window->GetHeight() : buffer_height;
+      if (expected_width != result.shape()[1] ||
+          expected_height != result.shape()[0]) {
+        TF_RUNTIME_ERROR("Buffer size mismatch: %lu x %lu vs %lu x %lu",
+                         expected_width, expected_height, result.shape()[1],
                          result.shape()[0]);
         return;
       }
@@ -924,7 +978,7 @@ class SceneModel final : public SceneManager {
       destinations_.push_back({req.buffer, static_cast<int>(current_offset), req.channel_count, is_int});
       current_offset += req.channel_count;
     }
-    PerformBatchedCopy<Float>(display_result, destinations_);
+    PerformBatchedCopy<Float>(display_result, destinations_, crop_window);
 
     // 6. Set convergence status
     bool converged =

--- a/hdmitsuba/scene_manager.h
+++ b/hdmitsuba/scene_manager.h
@@ -24,6 +24,8 @@
 #include <pxr/base/vt/dictionary.h>
 #include <pxr/base/vt/types.h>
 #include <pxr/imaging/hd/aov.h>
+#include <optional>
+#include <pxr/base/gf/rect2i.h>
 #include <pxr/imaging/hd/camera.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
@@ -61,8 +63,10 @@ class SceneManager {
       const HdRenderPass* render_pass,
       const HdRenderPassAovBindingVector& aov_bindings) = 0;
 
-  virtual void Render(const HdRenderPass* render_pass,
-                      const HdCamera* camera) = 0;
+  virtual void Render(
+      const HdRenderPass* render_pass,
+      const HdCamera* camera,
+      const std::optional<GfRect2i>& crop_window = std::nullopt) = 0;
 
   virtual bool IsConverged(const HdRenderPass* render_pass) const = 0;
 

--- a/hdmitsuba/tests/render_settings_test.py
+++ b/hdmitsuba/tests/render_settings_test.py
@@ -207,3 +207,117 @@ def test_aovs_duplicate_resolving():
   assert "primId" in results
   assert "instanceId" in results
   np.testing.assert_array_equal(results["primId"], results["instanceId"])
+
+
+def test_crop_rendering():
+  stage = Usd.Stage.Open(f"{test_helpers.TEST_ASSETS_PATH}/shapes/cube.usda")
+  render_settings = test_helpers.create_render_settings(
+      stage, resolution=(512, 512)
+  )
+  settings_prim = render_settings.GetPrim()
+
+  settings_prim.CreateAttribute(
+      "mitsuba:sample_count", Sdf.ValueTypeNames.Int
+  ).Set(4)
+  settings_prim.CreateAttribute(
+      "mitsuba:integrator:type", Sdf.ValueTypeNames.String
+  ).Set("path")
+
+  # Render full image first
+  engine = usd_render.RenderEngine(stage)
+  engine.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
+  image_full = engine.render()["color"]
+
+  # Configure crop rendering (center 128x128 region)
+  render_settings.CreateDataWindowNDCAttr().Set((0.375, 0.375, 0.625, 0.625))
+
+  # Re-render with crop
+  engine_crop = usd_render.RenderEngine(stage)
+  engine_crop.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
+  image_crop = engine_crop.render()["color"]
+
+  test_helpers.write_image(image_full, "test_crop_rendering_full.png")
+  test_helpers.write_image(image_crop, "test_crop_rendering_crop.png")
+
+  # Verify that the cropped image has the same content in the cropped region
+  # (192 to 320 in x and y coordinates)
+  crop_region_full = image_full[192:320, 192:320, :3]
+  crop_region_crop = image_crop[192:320, 192:320, :3]
+  test_helpers.robust_assert_close(
+      crop_region_crop, crop_region_full, atol=0.1
+  )
+
+  # Verify that everything else in image_crop is black (zeros)
+  mask = np.ones((512, 512, 3), dtype=bool)
+  mask[192:320, 192:320, :] = False
+
+  mismatched_coords = np.argwhere((image_crop[..., :3] != 0.0) & mask)
+  print(f"Number of mismatched pixels/channels: {len(mismatched_coords)}")
+  non_zero_coords = np.argwhere(image_crop[..., :3] != 0.0)
+  if len(non_zero_coords) > 0:
+    min_y, min_x, _ = non_zero_coords.min(axis=0)
+    max_y, max_x, _ = non_zero_coords.max(axis=0)
+    print(
+        f"Non-zero bounding box: y in [{min_y}, {max_y}], x in [{min_x},"
+        f" {max_x}]"
+    )
+  assert len(mismatched_coords) == 0
+
+
+def test_asymmetric_crop_rendering():
+  stage = Usd.Stage.Open(f"{test_helpers.TEST_ASSETS_PATH}/shapes/cube.usda")
+  render_settings = test_helpers.create_render_settings(
+      stage, resolution=(512, 512)
+  )
+  settings_prim = render_settings.GetPrim()
+
+  settings_prim.CreateAttribute(
+      "mitsuba:sample_count", Sdf.ValueTypeNames.Int
+  ).Set(4)
+  settings_prim.CreateAttribute(
+      "mitsuba:integrator:type", Sdf.ValueTypeNames.String
+  ).Set("path")
+
+  # Render full image first
+  engine = usd_render.RenderEngine(stage)
+  engine.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
+  image_full = engine.render()["color"]
+
+  # Configure asymmetric crop rendering (x: [0.25, 0.75], y: [0.1, 0.4] in Y-up NDC)
+  # y range 0.1 to 0.4 maps to rows [51, 204] in Y-up pixel coordinates.
+  render_settings.CreateDataWindowNDCAttr().Set((0.25, 0.1, 0.75, 0.4))
+
+  # Re-render with crop
+  engine_crop = usd_render.RenderEngine(stage)
+  engine_crop.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
+  image_crop = engine_crop.render()["color"]
+
+  test_helpers.write_image(
+      image_full, "test_asymmetric_crop_rendering_full.png"
+  )
+  test_helpers.write_image(
+      image_crop, "test_asymmetric_crop_rendering_crop.png"
+  )
+
+  # Verify content in cropped region (rows [307, 460], cols [128, 384] inclusive, so [307:461, 128:384])
+  crop_region_full = image_full[307:461, 128:384, :3]
+  crop_region_crop = image_crop[307:461, 128:384, :3]
+  test_helpers.robust_assert_close(
+      crop_region_crop, crop_region_full, atol=0.1
+  )
+
+  # Verify everything else is black
+  mask = np.ones((512, 512, 3), dtype=bool)
+  mask[307:461, 128:384, :] = False
+  mismatched_coords = np.argwhere((image_crop[..., :3] != 0.0) & mask)
+
+  non_zero_coords = np.argwhere(image_crop[..., :3] != 0.0)
+  if len(non_zero_coords) > 0:
+    min_y, min_x, _ = non_zero_coords.min(axis=0)
+    max_y, max_x, _ = non_zero_coords.max(axis=0)
+    print(
+        f"Asymmetric crop non-zero bounding box: y in [{min_y}, {max_y}], x"
+        f" in [{min_x}, {max_x}]"
+    )
+  assert len(mismatched_coords) == 0
+

--- a/hdmitsuba/tests/render_settings_test.py
+++ b/hdmitsuba/tests/render_settings_test.py
@@ -228,61 +228,6 @@ def test_crop_rendering():
   engine.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
   image_full = engine.render()["color"]
 
-  # Configure crop rendering (center 128x128 region)
-  render_settings.CreateDataWindowNDCAttr().Set((0.375, 0.375, 0.625, 0.625))
-
-  # Re-render with crop
-  engine_crop = usd_render.RenderEngine(stage)
-  engine_crop.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
-  image_crop = engine_crop.render()["color"]
-
-  test_helpers.write_image(image_full, "test_crop_rendering_full.png")
-  test_helpers.write_image(image_crop, "test_crop_rendering_crop.png")
-
-  # Verify that the cropped image has the same content in the cropped region
-  # (192 to 320 in x and y coordinates)
-  crop_region_full = image_full[192:320, 192:320, :3]
-  crop_region_crop = image_crop[192:320, 192:320, :3]
-  test_helpers.robust_assert_close(
-      crop_region_crop, crop_region_full, atol=0.1
-  )
-
-  # Verify that everything else in image_crop is black (zeros)
-  mask = np.ones((512, 512, 3), dtype=bool)
-  mask[192:320, 192:320, :] = False
-
-  mismatched_coords = np.argwhere((image_crop[..., :3] != 0.0) & mask)
-  print(f"Number of mismatched pixels/channels: {len(mismatched_coords)}")
-  non_zero_coords = np.argwhere(image_crop[..., :3] != 0.0)
-  if len(non_zero_coords) > 0:
-    min_y, min_x, _ = non_zero_coords.min(axis=0)
-    max_y, max_x, _ = non_zero_coords.max(axis=0)
-    print(
-        f"Non-zero bounding box: y in [{min_y}, {max_y}], x in [{min_x},"
-        f" {max_x}]"
-    )
-  assert len(mismatched_coords) == 0
-
-
-def test_asymmetric_crop_rendering():
-  stage = Usd.Stage.Open(f"{test_helpers.TEST_ASSETS_PATH}/shapes/cube.usda")
-  render_settings = test_helpers.create_render_settings(
-      stage, resolution=(512, 512)
-  )
-  settings_prim = render_settings.GetPrim()
-
-  settings_prim.CreateAttribute(
-      "mitsuba:sample_count", Sdf.ValueTypeNames.Int
-  ).Set(4)
-  settings_prim.CreateAttribute(
-      "mitsuba:integrator:type", Sdf.ValueTypeNames.String
-  ).Set("path")
-
-  # Render full image first
-  engine = usd_render.RenderEngine(stage)
-  engine.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
-  image_full = engine.render()["color"]
-
   # Configure asymmetric crop rendering (x: [0.25, 0.75], y: [0.1, 0.4] in Y-up NDC)
   # y range 0.1 to 0.4 maps to rows [51, 204] in Y-up pixel coordinates.
   render_settings.CreateDataWindowNDCAttr().Set((0.25, 0.1, 0.75, 0.4))
@@ -292,12 +237,8 @@ def test_asymmetric_crop_rendering():
   engine_crop.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
   image_crop = engine_crop.render()["color"]
 
-  test_helpers.write_image(
-      image_full, "test_asymmetric_crop_rendering_full.png"
-  )
-  test_helpers.write_image(
-      image_crop, "test_asymmetric_crop_rendering_crop.png"
-  )
+  test_helpers.write_image(image_full, "test_crop_rendering_full.png")
+  test_helpers.write_image(image_crop, "test_crop_rendering_crop.png")
 
   # Verify content in cropped region (rows [307, 460], cols [128, 384] inclusive, so [307:461, 128:384])
   crop_region_full = image_full[307:461, 128:384, :3]
@@ -320,4 +261,5 @@ def test_asymmetric_crop_rendering():
         f" in [{min_x}, {max_x}]"
     )
   assert len(mismatched_coords) == 0
+
 

--- a/hdmitsuba/tests/render_settings_test.py
+++ b/hdmitsuba/tests/render_settings_test.py
@@ -219,17 +219,12 @@ def test_crop_rendering():
   settings_prim.CreateAttribute(
       "mitsuba:sample_count", Sdf.ValueTypeNames.Int
   ).Set(4)
-  settings_prim.CreateAttribute(
-      "mitsuba:integrator:type", Sdf.ValueTypeNames.String
-  ).Set("path")
 
   # Render full image first
   engine = usd_render.RenderEngine(stage)
   engine.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
   image_full = engine.render()["color"]
 
-  # Configure asymmetric crop rendering (x: [0.25, 0.75], y: [0.1, 0.4] in Y-up NDC)
-  # y range 0.1 to 0.4 maps to rows [51, 204] in Y-up pixel coordinates.
   render_settings.CreateDataWindowNDCAttr().Set((0.25, 0.1, 0.75, 0.4))
 
   # Re-render with crop
@@ -244,22 +239,12 @@ def test_crop_rendering():
   crop_region_full = image_full[307:461, 128:384, :3]
   crop_region_crop = image_crop[307:461, 128:384, :3]
   test_helpers.robust_assert_close(
-      crop_region_crop, crop_region_full, atol=0.1
+      crop_region_crop, crop_region_full, atol=0.02
   )
 
   # Verify everything else is black
-  mask = np.ones((512, 512, 3), dtype=bool)
-  mask[307:461, 128:384, :] = False
-  mismatched_coords = np.argwhere((image_crop[..., :3] != 0.0) & mask)
-
-  non_zero_coords = np.argwhere(image_crop[..., :3] != 0.0)
-  if len(non_zero_coords) > 0:
-    min_y, min_x, _ = non_zero_coords.min(axis=0)
-    max_y, max_x, _ = non_zero_coords.max(axis=0)
-    print(
-        f"Asymmetric crop non-zero bounding box: y in [{min_y}, {max_y}], x"
-        f" in [{min_x}, {max_x}]"
-    )
-  assert len(mismatched_coords) == 0
+  mask = np.ones((512, 512), dtype=bool)
+  mask[307:461, 128:384] = False
+  np.testing.assert_array_equal(image_crop[..., :3][mask], 0.0)
 
 

--- a/render_engine/engine.cc
+++ b/render_engine/engine.cc
@@ -37,6 +37,7 @@
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/dictionary.h>
 #include <pxr/base/vt/value.h>
+#include <pxr/imaging/cameraUtil/framing.h>
 #include <pxr/imaging/hd/aov.h>
 #include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h>
@@ -200,7 +201,9 @@ bool AovInfosChanged(const std::vector<RenderEngine::AovInfo>& old_aovs,
 
 }  // namespace
 
-RenderEngine::RenderEngine(UsdStagePtr stage) : stage_(stage) {
+RenderEngine::RenderEngine(UsdStagePtr stage)
+    : stage_(stage),
+      data_window_ndc_(GfVec2f(0.0f, 0.0f), GfVec2f(1.0f, 1.0f)) {
   engine_ = std::make_unique<HdEngine>();
 }
 
@@ -305,6 +308,16 @@ void RenderEngine::Configure(
   for (const auto& [key, value] : overrides) {
     settings_map[key] = value;
   }
+
+  GfRange2f new_data_window_ndc(GfVec2f(0.0f, 0.0f), GfVec2f(1.0f, 1.0f));
+  TfToken ndc_token("dataWindowNDC");
+  auto ndc_it = settings_map.find(ndc_token);
+  if (ndc_it != settings_map.end() && ndc_it->second.IsHolding<GfVec4f>()) {
+    GfVec4f ndc = ndc_it->second.Get<GfVec4f>();
+    new_data_window_ndc =
+        GfRange2f(GfVec2f(ndc[0], ndc[1]), GfVec2f(ndc[2], ndc[3]));
+  }
+  bool ndc_changed = (new_data_window_ndc != data_window_ndc_);
 
   // Unconditionally disable progressive refinement in the batch render engine
   settings_map[pxr::HdRenderSettingsTokens->enableInteractive] =
@@ -424,6 +437,23 @@ void RenderEngine::Configure(
     scene_delegate_->SetRefineLevelFallback(refine_level_fallback.value());
   }
 
+  auto compute_framing = [](const GfRange2f& ndc, const GfVec2i& resolution) {
+    CameraUtilFraming framing;
+    if (!ndc.IsEmpty()) {
+      GfRange2f displayWindow(GfVec2f(0.0f, 0.0f),
+                              GfVec2f(resolution[0], resolution[1]));
+      int minX = std::round(ndc.GetMin()[0] * resolution[0]);
+      int minY = std::round((1.0f - ndc.GetMax()[1]) * resolution[1]);
+      int maxX = std::round(ndc.GetMax()[0] * resolution[0]) - 1;
+      int maxY = std::round((1.0f - ndc.GetMin()[1]) * resolution[1]) - 1;
+      maxX = std::max(minX, std::min(maxX, resolution[0] - 1));
+      maxY = std::max(minY, std::min(maxY, resolution[1] - 1));
+      framing = CameraUtilFraming(
+          displayWindow, GfRect2i(GfVec2i(minX, minY), GfVec2i(maxX, maxY)));
+    }
+    return framing;
+  };
+
   if (cache_invalid) {
     // This update is necessary to correctly update render buffer resolutions.
     CreateRenderBuffers();
@@ -440,6 +470,7 @@ void RenderEngine::Configure(
       HdxRenderTaskParams params{};
       params.aovBindings = CreateAovBindings();
       params.viewport = GfVec4d(0, 0, resolution_[0], resolution_[1]);
+      params.framing = compute_framing(new_data_window_ndc, resolution_);
       params_delegate_->SetParameter(render_task_id_, HdTokens->params, params);
       params_delegate_->SetParameter(render_task_id_, HdTokens->collection,
                                      collection);
@@ -449,7 +480,16 @@ void RenderEngine::Configure(
       tasks_.push_back(render_index_->GetTask(render_task_id_));
     }
     SetCamera(camera_path_);
+  } else if (ndc_changed) {
+    auto params = params_delegate_->GetParameter<HdxRenderTaskParams>(
+        render_task_id_, HdTokens->params);
+    params.framing = compute_framing(new_data_window_ndc, resolution_);
+    params_delegate_->SetParameter(render_task_id_, HdTokens->params, params);
+    render_index_->GetChangeTracker().MarkTaskDirty(
+        render_task_id_, HdChangeTracker::DirtyParams);
   }
+
+  data_window_ndc_ = new_data_window_ndc;
 }
 
 void RenderEngine::SetCamera(const SdfPath& camera) {

--- a/render_engine/engine.cc
+++ b/render_engine/engine.cc
@@ -201,20 +201,19 @@ bool AovInfosChanged(const std::vector<RenderEngine::AovInfo>& old_aovs,
 
 CameraUtilFraming ComputeFraming(const GfRange2f& ndc,
                                  const GfVec2i& resolution) {
-  CameraUtilFraming framing;
-  if (!ndc.IsEmpty()) {
-    GfRange2f displayWindow(GfVec2f(0.0f, 0.0f),
-                            GfVec2f(resolution[0], resolution[1]));
-    int minX = std::round(ndc.GetMin()[0] * resolution[0]);
-    int minY = std::round((1.0f - ndc.GetMax()[1]) * resolution[1]);
-    int maxX = std::round(ndc.GetMax()[0] * resolution[0]) - 1;
-    int maxY = std::round((1.0f - ndc.GetMin()[1]) * resolution[1]) - 1;
-    maxX = std::max(minX, std::min(maxX, resolution[0] - 1));
-    maxY = std::max(minY, std::min(maxY, resolution[1] - 1));
-    framing = CameraUtilFraming(
-        displayWindow, GfRect2i(GfVec2i(minX, minY), GfVec2i(maxX, maxY)));
+  if (ndc.IsEmpty()) {
+    return {};
   }
-  return framing;
+  GfRange2f display_window(GfVec2f(0.0f, 0.0f),
+                           GfVec2f(resolution[0], resolution[1]));
+  int min_x = std::round(ndc.GetMin()[0] * resolution[0]);
+  int min_y = std::round((1.0f - ndc.GetMax()[1]) * resolution[1]);
+  int max_x = std::round(ndc.GetMax()[0] * resolution[0]) - 1;
+  int max_y = std::round((1.0f - ndc.GetMin()[1]) * resolution[1]) - 1;
+  max_x = std::max(min_x, std::min(max_x, resolution[0] - 1));
+  max_y = std::max(min_y, std::min(max_y, resolution[1] - 1));
+  return CameraUtilFraming(
+      display_window, GfRect2i(GfVec2i(min_x, min_y), GfVec2i(max_x, max_y)));
 }
 
 }  // namespace

--- a/render_engine/engine.cc
+++ b/render_engine/engine.cc
@@ -199,6 +199,24 @@ bool AovInfosChanged(const std::vector<RenderEngine::AovInfo>& old_aovs,
   return false;
 }
 
+CameraUtilFraming ComputeFraming(const GfRange2f& ndc,
+                                 const GfVec2i& resolution) {
+  CameraUtilFraming framing;
+  if (!ndc.IsEmpty()) {
+    GfRange2f displayWindow(GfVec2f(0.0f, 0.0f),
+                            GfVec2f(resolution[0], resolution[1]));
+    int minX = std::round(ndc.GetMin()[0] * resolution[0]);
+    int minY = std::round((1.0f - ndc.GetMax()[1]) * resolution[1]);
+    int maxX = std::round(ndc.GetMax()[0] * resolution[0]) - 1;
+    int maxY = std::round((1.0f - ndc.GetMin()[1]) * resolution[1]) - 1;
+    maxX = std::max(minX, std::min(maxX, resolution[0] - 1));
+    maxY = std::max(minY, std::min(maxY, resolution[1] - 1));
+    framing = CameraUtilFraming(
+        displayWindow, GfRect2i(GfVec2i(minX, minY), GfVec2i(maxX, maxY)));
+  }
+  return framing;
+}
+
 }  // namespace
 
 RenderEngine::RenderEngine(UsdStagePtr stage)
@@ -437,23 +455,6 @@ void RenderEngine::Configure(
     scene_delegate_->SetRefineLevelFallback(refine_level_fallback.value());
   }
 
-  auto compute_framing = [](const GfRange2f& ndc, const GfVec2i& resolution) {
-    CameraUtilFraming framing;
-    if (!ndc.IsEmpty()) {
-      GfRange2f displayWindow(GfVec2f(0.0f, 0.0f),
-                              GfVec2f(resolution[0], resolution[1]));
-      int minX = std::round(ndc.GetMin()[0] * resolution[0]);
-      int minY = std::round((1.0f - ndc.GetMax()[1]) * resolution[1]);
-      int maxX = std::round(ndc.GetMax()[0] * resolution[0]) - 1;
-      int maxY = std::round((1.0f - ndc.GetMin()[1]) * resolution[1]) - 1;
-      maxX = std::max(minX, std::min(maxX, resolution[0] - 1));
-      maxY = std::max(minY, std::min(maxY, resolution[1] - 1));
-      framing = CameraUtilFraming(
-          displayWindow, GfRect2i(GfVec2i(minX, minY), GfVec2i(maxX, maxY)));
-    }
-    return framing;
-  };
-
   if (cache_invalid) {
     // This update is necessary to correctly update render buffer resolutions.
     CreateRenderBuffers();
@@ -470,7 +471,7 @@ void RenderEngine::Configure(
       HdxRenderTaskParams params{};
       params.aovBindings = CreateAovBindings();
       params.viewport = GfVec4d(0, 0, resolution_[0], resolution_[1]);
-      params.framing = compute_framing(new_data_window_ndc, resolution_);
+      params.framing = ComputeFraming(new_data_window_ndc, resolution_);
       params_delegate_->SetParameter(render_task_id_, HdTokens->params, params);
       params_delegate_->SetParameter(render_task_id_, HdTokens->collection,
                                      collection);
@@ -483,7 +484,7 @@ void RenderEngine::Configure(
   } else if (ndc_changed) {
     auto params = params_delegate_->GetParameter<HdxRenderTaskParams>(
         render_task_id_, HdTokens->params);
-    params.framing = compute_framing(new_data_window_ndc, resolution_);
+    params.framing = ComputeFraming(new_data_window_ndc, resolution_);
     params_delegate_->SetParameter(render_task_id_, HdTokens->params, params);
     render_index_->GetChangeTracker().MarkTaskDirty(
         render_task_id_, HdChangeTracker::DirtyParams);

--- a/render_engine/engine.h
+++ b/render_engine/engine.h
@@ -123,6 +123,7 @@ class RenderEngine {
   pxr::SdfPath camera_path_;
   int width_;
   pxr::HdRenderSettingsMap settings_map_;
+  pxr::GfRange2f data_window_ndc_;
 };
 
 }  // namespace hdmitsuba

--- a/usd_mitsuba/camera.py
+++ b/usd_mitsuba/camera.py
@@ -116,6 +116,36 @@ def usd_to_mitsuba(
       sensor_dict['near_clip'] = clipping_range[0]
       sensor_dict['far_clip'] = clipping_range[1]
 
+  film_dict = sensor_dict['film']
+  assert isinstance(film_dict, dict)
+
+  # Apply crop window if present in render settings
+  if render_settings:
+    ndc_attr = render_settings.GetDataWindowNDCAttr()
+    if ndc_attr.HasAuthoredValue():
+      ndc = ndc_attr.Get(time)
+      ndc = tuple(ndc)
+      if ndc != (0.0, 0.0, 1.0, 1.0):
+        width, height = image_size
+        xmin, ymin, xmax, ymax = ndc
+
+        # Calculate pixel-space crop
+        crop_offset_x = int(round(xmin * width))
+        crop_offset_y = int(round((1.0 - ymax) * height))
+        crop_width = int(round(xmax * width)) - crop_offset_x
+        crop_height = int(round((1.0 - ymin) * height)) - crop_offset_y
+
+        # Ensure values are within bounds
+        crop_offset_x = max(0, min(crop_offset_x, width - 1))
+        crop_offset_y = max(0, min(crop_offset_y, height - 1))
+        crop_width = max(1, min(crop_width, width - crop_offset_x))
+        crop_height = max(1, min(crop_height, height - crop_offset_y))
+
+        film_dict['crop_width'] = crop_width
+        film_dict['crop_height'] = crop_height
+        film_dict['crop_offset_x'] = crop_offset_x
+        film_dict['crop_offset_y'] = crop_offset_y
+
   # TODO: Modify this to also support specifying 'mitsuba:sampler:sample_count'.
   sample_count = 1
   if render_settings:
@@ -129,7 +159,5 @@ def usd_to_mitsuba(
   }
 
   if reconstruction_filter is not None:
-    film_dict = sensor_dict.setdefault('film', {})
-    assert isinstance(film_dict, dict)
     film_dict['reconstruction_filter'] = reconstruction_filter
   return sensor_dict

--- a/usd_mitsuba/tests/camera_test.py
+++ b/usd_mitsuba/tests/camera_test.py
@@ -147,3 +147,31 @@ def test_convert_to_mitsuba_with_time(
       np.array(expected_transform).T,
       atol=1e-4,
   )
+
+
+def test_convert_to_mitsuba_with_crop():
+  stage, _ = _create_camera_stage()
+  camera_prim = UsdGeom.Camera(stage.GetPrimAtPath("/World/MyCamera"))
+
+  # Set crop window on render settings
+  render_settings = UsdRender.Settings(stage.GetPrimAtPath("/Render/Settings"))
+  # dataWindowNDC: (0.25, 0.1, 0.75, 0.4)
+  # resolution is (200, 100)
+  render_settings.CreateDataWindowNDCAttr().Set((0.25, 0.1, 0.75, 0.4))
+
+  mitsuba_camera = camera.usd_to_mitsuba(camera_prim)
+
+  # Expected crop values:
+  # width = 200, height = 100
+  # xmin=0.25, ymin=0.1, xmax=0.75, ymax=0.4
+  # crop_offset_x = round(0.25 * 200) = 50
+  # crop_offset_y = round((1.0 - 0.4) * 100) = 60
+  # crop_width = round(0.75 * 200) - 50 = 150 - 50 = 100
+  # crop_height = round((1.0 - 0.1) * 100) - 60 = 90 - 60 = 30
+
+  film = mitsuba_camera["film"]
+  assert film["crop_offset_x"] == 50
+  assert film["crop_offset_y"] == 60
+  assert film["crop_width"] == 100
+  assert film["crop_height"] == 30
+


### PR DESCRIPTION
This PR implements dataWindowNDC support in hdMitsuba to enable crop rendering (partial region rendering).

**Key Changes:**
* **Core Implementation**: Updated scene_manager.cc and render_pass.cc to respect the dataWindowNDC render setting token. It correctly calculates the framing bounding boxes based on the normalized device coordinates and handles Y-up to Y-down coordinate mappings for buffer copies.
* **RenderEngine Updates**: Extended the local RenderEngine to trackdataWindowNDC changes and concisely update the render task parameters (HdxRenderTaskParams.framing) accordingly.
* **Testing**: Added comprehensive tests in render_settings_test.py (test_asymmetric_crop_rendering) to verify that the cropped region renders exactly as expected while the outside regions remain unrendered (black).