### PR TITLE
Support Mitsuba-specific non-color inputs and default color space to auto.

### DIFF
--- a/hdmitsuba/prim_translator.cc
+++ b/hdmitsuba/prim_translator.cc
@@ -104,7 +104,9 @@ bool UseRawBitmap(const TfToken& source_color_space,
       absl::flat_hash_set<TfToken, TfToken::HashFunctor>>
       kNonColorInputs({
           TfToken("normal"),
+          TfToken("normalmap"),
           TfToken("bump"),
+          TfToken("bumpmap"),
           TfToken("roughness"),
           TfToken("metallic"),
           TfToken("displacement"),
@@ -202,12 +204,13 @@ std::optional<mitsuba::Properties> ExtractTextureProperties(
                           input_name == TfToken("normalmap")));
   if (nodeTypeId == TfToken("UsdUVTexture")) {
     auto source_color_space_it = parameters.find(TfToken("sourceColorSpace"));
+    TfToken source_color_space = TfToken("auto");
     if (source_color_space_it != parameters.end() &&
         source_color_space_it->second.IsHolding<TfToken>()) {
-      bool is_raw = UseRawBitmap(source_color_space_it->second.Get<TfToken>(),
-                                 input_name);
-      props.set("raw", is_raw);
+      source_color_space = source_color_space_it->second.Get<TfToken>();
     }
+    bool is_raw = UseRawBitmap(source_color_space, input_name);
+    props.set("raw", is_raw);
     auto wrap_s_it = parameters.find(TfToken("wrapS"));
     if (wrap_s_it != parameters.end() &&
         wrap_s_it->second.IsHolding<TfToken>()) {

--- a/usd_mitsuba/material.py
+++ b/usd_mitsuba/material.py
@@ -53,7 +53,7 @@ MI_TO_USD_PRINCIPLED_RENAMING = {
 # Standard non-color shader inputs defined in the UsdPreviewSurface
 # specification. Ref:
 # third_party/usd/v23/pxr/usdImaging/plugin/usdShaders/shaders/shaderDefs.usda
-_USD_NON_COLOR_INPUTS = frozenset({
+_USD_PREVIEW_SURFACE_NON_COLOR_INPUTS = frozenset({
     'normal',
     'bump',
     'roughness',
@@ -65,6 +65,16 @@ _USD_NON_COLOR_INPUTS = frozenset({
     'ior',
     'opacity',
 })
+
+# Mitsuba-specific non-color shader inputs for custom shaders.
+_MITSUBA_NON_COLOR_INPUTS = frozenset({
+    'normalmap',
+    'bumpmap',
+})
+
+_NON_COLOR_INPUTS = (
+    _USD_PREVIEW_SURFACE_NON_COLOR_INPUTS | _MITSUBA_NON_COLOR_INPUTS
+)
 
 _SUPPORTED_IMAGE_EXTENSIONS = frozenset({
     '.exr',
@@ -131,13 +141,15 @@ def _convert_uv_texture(
       texture = {'type': 'bitmap', 'filename': filename}
 
       # Handle color space if we have a bitmap.
-      if source_color_space := shader.GetInput('sourceColorSpace').Get():
-        is_non_color = input_name in _USD_NON_COLOR_INPUTS
-        if source_color_space == 'auto':
-          if is_non_color:
-            texture['raw'] = True
-        else:
-          texture['raw'] = (source_color_space == 'raw') and is_non_color
+      source_color_space = shader.GetInput('sourceColorSpace').Get()
+      if source_color_space is None:
+        source_color_space = 'auto'
+      is_non_color = input_name in _NON_COLOR_INPUTS
+      if source_color_space == 'auto':
+        if is_non_color:
+          texture['raw'] = True
+      else:
+        texture['raw'] = (source_color_space == 'raw') and is_non_color
       return texture
     else:
       Tf.Warn(
@@ -157,7 +169,10 @@ def _convert_uv_texture(
   return {'type': 'rgb', 'value': (1.0, 0.0, 1.0)}
 
 
-def usd_mitsuba_material_to_dict(shader: UsdShade.Shader) -> dict[str, Any]:
+def usd_mitsuba_material_to_dict(
+    shader: UsdShade.Shader,
+    input_name: str | None = None,
+) -> dict[str, Any]:
   """Converts a USD shader to a Mitsuba BSDF dictionary."""
 
   def _traverse(
@@ -200,7 +215,7 @@ def usd_mitsuba_material_to_dict(shader: UsdShade.Shader) -> dict[str, Any]:
 
     return result
 
-  return _traverse(shader)
+  return _traverse(shader, input_name)
 
 
 def usd_preview_surface_to_mitsuba(
@@ -331,7 +346,7 @@ def convert_material(
         bsdf = mi.load_dict(bsdf_dict)
 
     if shader := find_shader(_get_displacement_output(material)):
-      bsdf_dict = usd_mitsuba_material_to_dict(shader)
+      bsdf_dict = usd_mitsuba_material_to_dict(shader, 'displacement')
       displacement = mi.load_dict(bsdf_dict)
       if not isinstance(displacement, mi.Texture):
         raise ValueError(

--- a/usd_mitsuba/tests/materials_test.py
+++ b/usd_mitsuba/tests/materials_test.py
@@ -54,7 +54,7 @@ MITSUBA_EXAMPLE_BSDFS = [
     },
     {
         'type': 'normalmap',
-        'normalmap': {'type': 'bitmap', 'filename': _NORMALMAP_PNG},
+        'normalmap': {'type': 'bitmap', 'filename': _NORMALMAP_PNG, 'raw': True},
         'nested_bsdf': {
             'type': 'roughplastic',
             'diffuse_reflectance': {
@@ -134,7 +134,7 @@ def test_mitsuba_to_usd_conversion(mitsuba_bsdf):
     },
     {
         'type': 'normalmap',
-        'normalmap': {'type': 'bitmap', 'filename': _NORMALMAP_PNG},
+        'normalmap': {'type': 'bitmap', 'filename': _NORMALMAP_PNG, 'raw': True},
         'nested_bsdf': {
             'type': 'principled',
             'base_color': {'type': 'bitmap', 'filename': _ALBEDO_PNG},
@@ -199,3 +199,16 @@ def test_usd_preview_surface_to_mitsuba_specular_eta_resolution():
   assert 'specular' in bsdf_dict
   assert bsdf_dict['specular'] == 0.5
   assert bsdf_dict['spec_trans'] == 0.0
+
+
+def test_displacement_texture_translation():
+  stage = Usd.Stage.CreateInMemory()
+  shader = UsdShade.Shader.Define(
+      stage, Sdf.Path('/Material/displacement_texture')
+  )
+  shader.CreateIdAttr('UsdUVTexture')
+  shader.CreateInput('file', Sdf.ValueTypeNames.Asset).Set(_ALBEDO_PNG)
+
+  result_dict = material.usd_mitsuba_material_to_dict(shader, 'displacement')
+  assert result_dict['raw']
+


### PR DESCRIPTION
- Adds 'normalmap' and 'bumpmap' to non-color inputs in both C++ and Python translators.
- Defaults missing 'sourceColorSpace' in USD texture shaders to 'auto' (in both C++ and Python).
- Propagates 'displacement' input name when translating displacement textures in Python to ensure they resolve to raw=true.
- Adds regression test for displacement texture translation.