### PR TITLE
Use box filter for interactive rendering

### DIFF
--- a/hdmitsuba/prim_translator.cc
+++ b/hdmitsuba/prim_translator.cc
@@ -773,7 +773,8 @@ MI_VARIANT void PrimTranslator<Float, Spectrum>::UpdateLightInPlace(
 }
 
 MI_VARIANT mitsuba::ref<mitsuba::Sensor<Float, Spectrum>>
-PrimTranslator<Float, Spectrum>::BuildSensor(const CameraSpec& spec) {
+PrimTranslator<Float, Spectrum>::BuildSensor(const CameraSpec& spec,
+                                             bool is_interactive) {
   mitsuba::Properties props;
   if (spec.sensor_type == "irradiancemeter") {
     props = mitsuba::Properties("irradiancemeter");
@@ -788,14 +789,14 @@ PrimTranslator<Float, Spectrum>::BuildSensor(const CameraSpec& spec) {
   props.set("near_clip", spec.near_clip);
   props.set("far_clip", spec.far_clip);
 
-  if (!spec.pixel_filter_type.empty()) {
+  if (!filter_type.empty()) {
     mitsuba::Properties film_props("hdrfilm");
     film_props.set(
         "pixel_filter",
         static_cast<mitsuba::Object*>(
             mitsuba::PluginManager::instance()
                 ->create_object<mitsuba::ReconstructionFilter<Float, Spectrum>>(
-                    mitsuba::Properties(spec.pixel_filter_type))
+                    mitsuba::Properties(is_interactive ? "box" : spec.pixel_filter_type))
                 .get()));
     props.set(
         "film",

--- a/hdmitsuba/prim_translator.cc
+++ b/hdmitsuba/prim_translator.cc
@@ -789,6 +789,7 @@ PrimTranslator<Float, Spectrum>::BuildSensor(const CameraSpec& spec,
   props.set("near_clip", spec.near_clip);
   props.set("far_clip", spec.far_clip);
 
+  std::string filter_type = is_interactive ? "box" : spec.pixel_filter_type;
   if (!filter_type.empty()) {
     mitsuba::Properties film_props("hdrfilm");
     film_props.set(
@@ -796,7 +797,7 @@ PrimTranslator<Float, Spectrum>::BuildSensor(const CameraSpec& spec,
         static_cast<mitsuba::Object*>(
             mitsuba::PluginManager::instance()
                 ->create_object<mitsuba::ReconstructionFilter<Float, Spectrum>>(
-                    mitsuba::Properties(is_interactive ? "box" : spec.pixel_filter_type))
+                    mitsuba::Properties(filter_type))
                 .get()));
     props.set(
         "film",

--- a/hdmitsuba/prim_translator.h
+++ b/hdmitsuba/prim_translator.h
@@ -86,7 +86,7 @@ class PrimTranslator {
                                  const LightSpec& spec);
 
   static mitsuba::ref<mitsuba::Sensor<Float, Spectrum>> BuildSensor(
-      const CameraSpec& spec);
+      const CameraSpec& spec, bool is_interactive = false);
 
   static void UpdateSensorInPlace(mitsuba::Object* sensor_obj,
                                   const CameraSpec& spec);

--- a/hdmitsuba/scene_manager.cc
+++ b/hdmitsuba/scene_manager.cc
@@ -1056,6 +1056,11 @@ class SceneModel final : public SceneManager {
         bool progressive = it->second.Get<bool>();
         if (progressive != progressive_rendering_) {
           progressive_rendering_ = progressive;
+          // A change in render mode requires rebuilding the sensors, since
+          // this affects the used pixel filter type.
+          for (auto& [_, camera_spec] : camera_specs_) {
+            camera_spec.needs_rebuild = true;
+          }
           reset_progressive_ = true;
         }
       }
@@ -1239,7 +1244,7 @@ class SceneModel final : public SceneManager {
         camera_specs_,
         [&](CameraSpec* spec, mitsuba::ref<Sensor>& res) {
           if (spec->needs_rebuild) {
-            res = PrimTranslator::BuildSensor(*spec);
+            res = PrimTranslator::BuildSensor(*spec, progressive_rendering_);
           } else if (spec->dirty_bits != 0) {
             if (spec->sensor_type != "irradiancemeter") {
               auto it = sensors_.find(spec->id.GetAsString());


### PR DESCRIPTION
Improve performance for interactive rendering by always using `box` filter by default in interactive modes