### PR TITLE
Fix: Avoid recursive object traversal during multi-threaded mesh updates

### DIFF
--- a/hdmitsuba/prim_translator.cc
+++ b/hdmitsuba/prim_translator.cc
@@ -897,7 +897,7 @@ MI_VARIANT void PrimTranslator<Float, Spectrum>::UpdateMeshInPlace(
   size_t face_count = face_indices.size() / 3;
   if (vertex_count == 0 || face_count == 0) return;
 
-  TraversalCallback cb;
+  TraversalCallback cb("", nullptr, /*recurse_objects=*/false);
   mesh->traverse(&cb);
 
   std::vector<std::string> keys = {"vertex_positions", "faces"};
@@ -953,7 +953,7 @@ PrimTranslator<Float, Spectrum>::BuildCurves(const CurveSpec& spec,
     shape->set_bsdf(dynamic_cast<mitsuba::BSDF<Float, Spectrum>*>(bsdf));
   }
 
-  TraversalCallback cb;
+  TraversalCallback cb("", nullptr, /*recurse_objects=*/false);
   shape->traverse(&cb);
 
   using FloatStorage = typename mitsuba::Mesh<Float, Spectrum>::FloatStorage;

--- a/hdmitsuba/traversal.cc
+++ b/hdmitsuba/traversal.cc
@@ -29,7 +29,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 using mitsuba::Object;
 
 TraversalCallback::TraversalCallback(std::string_view prefix, Object* parent,
-                                      bool recurse_objects)
+                                     bool recurse_objects)
     : prefix_(prefix), recurse_objects_(recurse_objects) {
   if (parent != nullptr) {
     hierarchy_.insert(parent);
@@ -38,8 +38,7 @@ TraversalCallback::TraversalCallback(std::string_view prefix, Object* parent,
 
 TraversalCallback::TraversalCallback(
     std::string_view prefix, Object* parent,
-    const absl::flat_hash_set<void*>& parent_hierarchy,
-    bool recurse_objects)
+    const absl::flat_hash_set<void*>& parent_hierarchy, bool recurse_objects)
     : hierarchy_(parent_hierarchy),
       prefix_(prefix),
       recurse_objects_(recurse_objects) {

--- a/hdmitsuba/traversal.cc
+++ b/hdmitsuba/traversal.cc
@@ -28,8 +28,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 using mitsuba::Object;
 
-TraversalCallback::TraversalCallback(std::string_view prefix, Object* parent)
-    : prefix_(prefix) {
+TraversalCallback::TraversalCallback(std::string_view prefix, Object* parent,
+                                      bool recurse_objects)
+    : prefix_(prefix), recurse_objects_(recurse_objects) {
   if (parent != nullptr) {
     hierarchy_.insert(parent);
   }
@@ -37,8 +38,11 @@ TraversalCallback::TraversalCallback(std::string_view prefix, Object* parent)
 
 TraversalCallback::TraversalCallback(
     std::string_view prefix, Object* parent,
-    const absl::flat_hash_set<void*>& parent_hierarchy)
-    : hierarchy_(parent_hierarchy), prefix_(prefix) {
+    const absl::flat_hash_set<void*>& parent_hierarchy,
+    bool recurse_objects)
+    : hierarchy_(parent_hierarchy),
+      prefix_(prefix),
+      recurse_objects_(recurse_objects) {
   if (parent != nullptr) {
     hierarchy_.insert(parent);
   }
@@ -53,10 +57,12 @@ void TraversalCallback::put_value(std::string_view name, void* value,
 /// Actual implementation for Object references [To be provided by subclass]
 void TraversalCallback::put_object(std::string_view name, Object* value,
                                    uint32_t /*flags*/) {
-  if (value == nullptr || hierarchy_.find(value) != hierarchy_.end()) {
-    return;  // prevent infinite recursion
+  if (!recurse_objects_ || value == nullptr ||
+      hierarchy_.find(value) != hierarchy_.end()) {
+    return;
   }
-  TraversalCallback cb(absl::StrCat(prefix_, name, "."), value, hierarchy_);
+  TraversalCallback cb(absl::StrCat(prefix_, name, "."), value, hierarchy_,
+                       recurse_objects_);
   value->traverse(&cb);
   for (auto& [name, value] : cb.data) {
     data.insert({std::move(name), std::move(value)});

--- a/hdmitsuba/traversal.h
+++ b/hdmitsuba/traversal.h
@@ -34,9 +34,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 class TraversalCallback : public mitsuba::TraversalCallback {
  public:
   explicit TraversalCallback(std::string_view prefix = "",
-                             mitsuba::Object* parent = nullptr);
+                             mitsuba::Object* parent = nullptr,
+                             bool recurse_objects = true);
   TraversalCallback(std::string_view prefix, mitsuba::Object* parent,
-                    const absl::flat_hash_set<void*>& parent_hierarchy);
+                    const absl::flat_hash_set<void*>& parent_hierarchy,
+                    bool recurse_objects = true);
 
   template <typename T>
   T* get(std::string_view name) {
@@ -74,6 +76,7 @@ class TraversalCallback : public mitsuba::TraversalCallback {
  private:
   absl::flat_hash_set<void*> hierarchy_;
   std::string prefix_;
+  bool recurse_objects_;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
Fixes a Dr.Jit concurrency issue when traversing objects in parallel. Specifically, during mesh/curve scene updates, we would (unnecessarily) recursively traverse BSDF instances. The BSDF instances are potentially shared across shapes, leading to race conditions / undefined behavior. The fix simply makes sure we do not recursively traverse these objects. This should fix some of the flaky tests we have observed.