### PR TITLE
Enable interactive variant change

### DIFF
--- a/hdmitsuba/render_delegate.cc
+++ b/hdmitsuba/render_delegate.cc
@@ -119,10 +119,11 @@ void HdMitsubaRenderDelegate::Initialize() {
                              VtValue(default_freezing)};
   _PopulateDefaultSettings(setting_descriptors_);
 
-  std::string variant = GetRenderSetting(HdMitsubaRenderSettingsTokens->variant)
-                            .Get<std::string>();
-  scene_impl_ =
-      std::unique_ptr<SceneManager>(SceneManager::CreateSceneManager(variant));
+  current_variant_ =
+      GetRenderSetting(HdMitsubaRenderSettingsTokens->variant)
+          .GetWithDefault<std::string>(HdMitsubaConfig::GetInstance().variant);
+  scene_impl_ = std::unique_ptr<SceneManager>(
+      SceneManager::CreateSceneManager(current_variant_));
   render_param_ = std::make_unique<HdMitsubaRenderParam>(scene_impl_.get());
 }
 
@@ -178,8 +179,8 @@ void HdMitsubaRenderDelegate::DestroyBprim(HdBprim* bPrim) { delete bPrim; }
 
 HdRenderPassSharedPtr HdMitsubaRenderDelegate::CreateRenderPass(
     HdRenderIndex* index, const HdRprimCollection& collection) {
-  return std::make_shared<HdMitsubaRenderPass>(index, collection,
-                                               scene_impl_.get());
+  render_index_ = index;
+  return std::make_shared<HdMitsubaRenderPass>(index, collection);
 }
 
 HdInstancer* HdMitsubaRenderDelegate::CreateInstancer(HdSceneDelegate* delegate,
@@ -213,7 +214,41 @@ HdBprim* HdMitsubaRenderDelegate::CreateFallbackBprim(const TfToken& typeId) {
   return nullptr;
 }
 
-void HdMitsubaRenderDelegate::CommitResources(HdChangeTracker* /*tracker*/) {
+void HdMitsubaRenderDelegate::MarkAllPrimsDirty(HdChangeTracker* tracker) {
+  tracker->MarkAllRprimsDirty(HdChangeTracker::AllDirty);
+  if (render_index_) {
+    for (const TfToken& sprim_type : GetSupportedSprimTypes()) {
+      for (const SdfPath& id : render_index_->GetSprimSubtree(
+               sprim_type, SdfPath::AbsoluteRootPath())) {
+        tracker->MarkSprimDirty(id, HdChangeTracker::AllDirty);
+      }
+    }
+    for (const TfToken& bprim_type : GetSupportedBprimTypes()) {
+      for (const SdfPath& id : render_index_->GetBprimSubtree(
+               bprim_type, SdfPath::AbsoluteRootPath())) {
+        tracker->MarkBprimDirty(id, HdChangeTracker::AllDirty);
+      }
+    }
+  }
+}
+
+void HdMitsubaRenderDelegate::CommitResources(HdChangeTracker* tracker) {
+  std::string target_variant =
+      GetRenderSetting(HdMitsubaRenderSettingsTokens->variant)
+          .GetWithDefault<std::string>(HdMitsubaConfig::GetInstance().variant);
+  if (!target_variant.empty() && current_variant_ != target_variant) {
+    TF_DEBUG(HDMITSUBA_LIFECYCLE)
+        .Msg(
+            "Mitsuba variant changed from '%s' to '%s'. Recreating "
+            "SceneManager.\n",
+            current_variant_.c_str(), target_variant.c_str());
+    scene_impl_ = std::unique_ptr<SceneManager>(
+        SceneManager::CreateSceneManager(target_variant));
+    render_param_->SetScene(scene_impl_.get());
+    current_variant_ = target_variant;
+    MarkAllPrimsDirty(tracker);
+  }
+
   VtDictionary namespaced_settings;
   namespaced_settings[HdMitsubaRenderSettingsTokens->variant.GetString()] =
       GetRenderSetting(HdMitsubaRenderSettingsTokens->variant);
@@ -224,7 +259,8 @@ void HdMitsubaRenderDelegate::CommitResources(HdChangeTracker* /*tracker*/) {
       GetRenderSetting(HdMitsubaRenderSettingsTokens->integrator_type);
   namespaced_settings["enableInteractive"] =
       GetRenderSetting(HdRenderSettingsTokens->enableInteractive);
-  namespaced_settings[HdMitsubaRenderSettingsTokens->use_kernel_freezing.GetString()] =
+  namespaced_settings[HdMitsubaRenderSettingsTokens->use_kernel_freezing
+                          .GetString()] =
       GetRenderSetting(HdMitsubaRenderSettingsTokens->use_kernel_freezing);
 
   scene_impl_->UpdateNamespacedSettings(namespaced_settings);

--- a/hdmitsuba/render_delegate.h
+++ b/hdmitsuba/render_delegate.h
@@ -82,6 +82,7 @@ class HdMitsubaRenderDelegate final : public HdRenderDelegate {
 
  private:
   void Initialize();
+  void MarkAllPrimsDirty(HdChangeTracker* tracker);
 
   // This class is not copyable.
   HdMitsubaRenderDelegate(const HdMitsubaRenderDelegate&) = delete;
@@ -89,6 +90,8 @@ class HdMitsubaRenderDelegate final : public HdRenderDelegate {
 
   std::unique_ptr<SceneManager> scene_impl_;
   std::unique_ptr<HdMitsubaRenderParam> render_param_;
+  HdRenderIndex* render_index_ = nullptr;
+  std::string current_variant_;
 
   HdRenderSettingDescriptorList setting_descriptors_;
 };

--- a/hdmitsuba/render_param.h
+++ b/hdmitsuba/render_param.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/pxr.h>
 
@@ -28,10 +30,11 @@ class HdMitsubaRenderParam final : public HdRenderParam {
  public:
   explicit HdMitsubaRenderParam(SceneManager* scene) : scene_(scene) {}
 
-  SceneManager* GetScene() const { return scene_; }
+  SceneManager* GetScene() const { return scene_.load(); }
+  void SetScene(SceneManager* scene) { scene_.store(scene); }
 
  private:
-  SceneManager* scene_;
+  std::atomic<SceneManager*> scene_;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/hdmitsuba/render_pass.cc
+++ b/hdmitsuba/render_pass.cc
@@ -25,16 +25,14 @@
 #include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/pxr.h>
 
+#include "hdmitsuba/render_param.h"
 #include "hdmitsuba/scene_manager.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdMitsubaRenderPass::HdMitsubaRenderPass(HdRenderIndex* index,
-                                         const HdRprimCollection& collection,
-                                         SceneManager* scene_manager)
-    : HdRenderPass(index, collection), scene_manager_(scene_manager) {
-  TF_VERIFY(scene_manager_ != nullptr);
-}
+                                         const HdRprimCollection& collection)
+    : HdRenderPass(index, collection) {}
 
 void HdMitsubaRenderPass::_Execute(
     const HdRenderPassStateSharedPtr& renderPassState,
@@ -46,19 +44,27 @@ void HdMitsubaRenderPass::_Execute(
   if (aov_bindings.empty()) {
     return;
   }
-  if (aov_bindings != aov_bindings_) {
-    scene_manager_->SetAovBindings(this, aov_bindings);
+
+  HdMitsubaRenderParam* render_param = static_cast<HdMitsubaRenderParam*>(
+      GetRenderIndex()->GetRenderDelegate()->GetRenderParam());
+  SceneManager* scene_manager = render_param->GetScene();
+  if (aov_bindings != aov_bindings_ || scene_manager != last_scene_manager_) {
+    scene_manager->SetAovBindings(this, aov_bindings);
     aov_bindings_ = aov_bindings;
+    last_scene_manager_ = scene_manager;
   }
   std::optional<GfRect2i> crop_window;
   if (renderPassState->GetFraming().IsValid()) {
     crop_window = renderPassState->GetFraming().dataWindow;
   }
-  scene_manager_->Render(this, renderPassState->GetCamera(), crop_window);
+  scene_manager->Render(this, renderPassState->GetCamera(), crop_window);
 }
 
 bool HdMitsubaRenderPass::IsConverged() const {
-  return scene_manager_->IsConverged(this);
+  return static_cast<HdMitsubaRenderParam*>(
+             GetRenderIndex()->GetRenderDelegate()->GetRenderParam())
+      ->GetScene()
+      ->IsConverged();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/hdmitsuba/render_pass.h
+++ b/hdmitsuba/render_pass.h
@@ -25,8 +25,8 @@ class SceneManager;
 
 class HdMitsubaRenderPass final : public HdRenderPass {
  public:
-  HdMitsubaRenderPass(HdRenderIndex* index, const HdRprimCollection& collection,
-                      SceneManager* scene_manager);
+  HdMitsubaRenderPass(HdRenderIndex* index,
+                      const HdRprimCollection& collection);
   ~HdMitsubaRenderPass() override = default;
 
   bool IsConverged() const override;
@@ -36,7 +36,7 @@ class HdMitsubaRenderPass final : public HdRenderPass {
                 const TfTokenVector& renderTags) override;
 
  private:
-  SceneManager* scene_manager_;
+  SceneManager* last_scene_manager_ = nullptr;
   HdRenderPassAovBindingVector aov_bindings_;
 };
 

--- a/hdmitsuba/scene_manager.cc
+++ b/hdmitsuba/scene_manager.cc
@@ -1013,7 +1013,7 @@ class SceneModel final : public SceneManager {
     }
   }
 
-  bool IsConverged(const HdRenderPass* /*render_pass*/) const override {
+  bool IsConverged() const override {
     if (!progressive_rendering_) {
       return true;
     }

--- a/hdmitsuba/scene_manager.cc
+++ b/hdmitsuba/scene_manager.cc
@@ -639,9 +639,7 @@ class SceneModel final : public SceneManager {
     TF_DEBUG(HDMITSUBA_SYNC).Msg("SyncCamera: %s\n", spec.id.GetText());
     absl::MutexLock lock(state_mutex_);
     auto prev_it = camera_specs_.find(spec.id);
-    if (!TF_VERIFY(prev_it != camera_specs_.end() || spec.needs_rebuild,
-                   "New camera spec %s must have needs_rebuild set.",
-                   spec.id.GetText())) {
+    if (prev_it == camera_specs_.end()) {
       spec.needs_rebuild = true;
     }
     if (prev_it != camera_specs_.end() && !spec.needs_rebuild) {
@@ -660,9 +658,7 @@ class SceneModel final : public SceneManager {
                                        : spec.material_ids[0].GetText());
     absl::MutexLock lock(state_mutex_);
     auto prev_it = mesh_specs_.find(spec.id);
-    if (!TF_VERIFY(prev_it != mesh_specs_.end() || spec.needs_rebuild,
-                   "New mesh spec %s must have needs_rebuild set.",
-                   spec.id.GetText())) {
+    if (prev_it == mesh_specs_.end()) {
       spec.needs_rebuild = true;
     }
     if (prev_it != mesh_specs_.end() && !spec.needs_rebuild) {
@@ -683,9 +679,7 @@ class SceneModel final : public SceneManager {
     TF_DEBUG(HDMITSUBA_SYNC).Msg("SyncLight: %s\n", spec.id.GetText());
     absl::MutexLock lock(state_mutex_);
     auto prev_it = light_specs_.find(spec.id);
-    if (!TF_VERIFY(prev_it != light_specs_.end() || spec.needs_rebuild,
-                   "New light spec %s must have needs_rebuild set.",
-                   spec.id.GetText())) {
+    if (prev_it == light_specs_.end()) {
       spec.needs_rebuild = true;
     }
     if (prev_it != light_specs_.end() && !spec.needs_rebuild) {

--- a/hdmitsuba/scene_manager.h
+++ b/hdmitsuba/scene_manager.h
@@ -68,7 +68,7 @@ class SceneManager {
       const HdCamera* camera,
       const std::optional<GfRect2i>& crop_window = std::nullopt) = 0;
 
-  virtual bool IsConverged(const HdRenderPass* render_pass) const = 0;
+  virtual bool IsConverged() const = 0;
 
   virtual void CommitResources() = 0;
 

--- a/hdmitsuba/tests/render_settings_test.py
+++ b/hdmitsuba/tests/render_settings_test.py
@@ -248,3 +248,23 @@ def test_crop_rendering():
   np.testing.assert_array_equal(image_crop[..., :3][mask], 0.0)
 
 
+def test_variant_change_dynamic():
+  stage = Usd.Stage.Open(f"{test_helpers.TEST_ASSETS_PATH}/shapes/cube.usda")
+  render_settings = test_helpers.create_render_settings(stage)
+  settings_prim = render_settings.GetPrim()
+
+  settings_prim.CreateAttribute(
+      "mitsuba:variant", Sdf.ValueTypeNames.String
+  ).Set("scalar_rgb")
+
+  engine = usd_render.RenderEngine(stage)
+  engine.configure(hydra_delegate_id="HdMitsubaRendererPlugin")
+  results_scalar = engine.render()
+
+  # Change the variant setting dynamically on the same stage and render engine
+  settings_prim.GetAttribute("mitsuba:variant").Set("llvm_ad_rgb")
+  results_llvm = engine.render()
+
+  test_helpers.robust_assert_close(
+      results_scalar["color"], results_llvm["color"], atol=0.05
+  )


### PR DESCRIPTION
Allows to change the variant interactively. Previously, the variant could only be set on startup. This is not a perfect solution, but at least allows to more easily check results using different variants. The logic to invalidate the scene state likely can be revisited once we fully transition to hydra 2.0