### PR TITLE
hdMitsuba: Store curve transform in spec and apply during shape build.

### DIFF
--- a/hdmitsuba/prim_translator.cc
+++ b/hdmitsuba/prim_translator.cc
@@ -979,7 +979,6 @@ PrimTranslator<Float, Spectrum>::BuildCurves(const CurveSpec& spec,
                                              mitsuba::Object* bsdf) {
   const std::string id_str = spec.id.GetAsString();
   mitsuba::Properties props(spec.plugin_name);
-  props.set("to_world", spec.transform);
   if (auto plugin =
           PlugRegistry::GetInstance().GetPluginWithName("hdMitsuba")) {
     props.set("filename", plugin->GetResourcePath() + "/curve.txt");
@@ -1002,10 +1001,21 @@ PrimTranslator<Float, Spectrum>::BuildCurves(const CurveSpec& spec,
   using IntStorage = mitsuba::DynamicBuffer<dr::uint32_array_t<Float>>;
   using ScalarSize = typename mitsuba::Shape<Float, Spectrum>::ScalarSize;
 
-  cb.set<ScalarSize>("control_point_count", spec.control_points.size() / 4);
+  using Point3f = mitsuba::Point<float, 3>;
+  std::vector<float> world_control_points = spec.control_points;
+  for (size_t i = 0; i < world_control_points.size(); i += 4) {
+    Point3f p(world_control_points[i], world_control_points[i + 1],
+              world_control_points[i + 2]);
+    p = spec.transform * p;
+    world_control_points[i + 0] = p[0];
+    world_control_points[i + 1] = p[1];
+    world_control_points[i + 2] = p[2];
+  }
+
+  cb.set<ScalarSize>("control_point_count", world_control_points.size() / 4);
   cb.set<FloatStorage>("control_points",
-                       dr::load<FloatStorage>(spec.control_points.data(),
-                                              spec.control_points.size()));
+                       dr::load<FloatStorage>(world_control_points.data(),
+                                              world_control_points.size()));
   cb.set<IntStorage>("segment_indices",
                      dr::load<IntStorage>(spec.segment_indices.data(),
                                           spec.segment_indices.size()));

--- a/hdmitsuba/tests/shape_test.py
+++ b/hdmitsuba/tests/shape_test.py
@@ -104,8 +104,9 @@ def test_curve_transform():
       output_prefix='test_curve_transform',
       atol=0.05,
   )
-  assert not np.allclose(
-      image_hd_modified[..., :3], image_original[..., :3], atol=0.01
+  assert (
+      np.max(np.abs(image_hd_modified[..., :3] - image_original[..., :3]))
+      > 0.2
   )
 
 
@@ -235,6 +236,6 @@ def test_modify_curve_transform_only():
       atol=0.05,
       engine=engine,
   )
-  assert not np.allclose(
-      image_modified[..., :3], image_original[..., :3], atol=0.01
+  assert (
+      np.max(np.abs(image_modified[..., :3] - image_original[..., :3])) > 0.2
   )

--- a/hdmitsuba/tests/shape_test.py
+++ b/hdmitsuba/tests/shape_test.py
@@ -88,6 +88,27 @@ def test_modify_shape_transform():
   np.testing.assert_allclose(image_modified, image_modified_2, atol=0.05)
 
 
+def test_curve_transform():
+  stage = Usd.Stage.Open(f'{test_helpers.TEST_ASSETS_PATH}/shapes/curve.usda')
+  test_helpers.create_render_settings(stage, resolution=(256, 256))
+  engine_orig = usd_render.RenderEngine(stage)
+  engine_orig.configure(hydra_delegate_id='HdMitsubaRendererPlugin')
+  image_original = engine_orig.render()['color']
+
+  curve_xform = UsdGeom.Xformable.Get(stage, '/root/mycurve')
+  curve_xform.AddTranslateOp(opSuffix='new_translation').Set((0.1, -0.1, 0.0))
+  curve_xform.AddRotateXYZOp(opSuffix='new_rotation').Set((0.0, 0.0, -15.0))
+  curve_xform.AddScaleOp(opSuffix='new_scale').Set((1.1, 0.9, 1.0))
+  image_hd_modified, _ = test_helpers.assert_hydra_equal_to_offline(
+      stage,
+      output_prefix='test_curve_transform',
+      atol=0.05,
+  )
+  assert not np.allclose(
+      image_hd_modified[..., :3], image_original[..., :3], atol=0.01
+  )
+
+
 def test_modify_points():
   stage = Usd.Stage.Open(f'{test_helpers.TEST_ASSETS_PATH}/shapes/cube.usda')
   test_helpers.create_render_settings(stage, resolution=(256, 256))
@@ -200,17 +221,20 @@ def test_modify_curve_width():
 
 def test_modify_curve_transform_only():
   stage = Usd.Stage.Open(f'{test_helpers.TEST_ASSETS_PATH}/shapes/curve.usda')
-  test_helpers.create_render_settings(stage, resolution=(64, 64))
+  test_helpers.create_render_settings(stage, resolution=(256, 256))
   engine = usd_render.RenderEngine(stage)
   engine.configure(hydra_delegate_id='HdMitsubaRendererPlugin')
-  _ = engine.render()['color']
+  image_original = engine.render()['color']
 
   curve_xform = UsdGeom.Xformable.Get(stage, '/root/mycurve')
   curve_xform.AddRotateZOp().Set(45.0)
 
-  test_helpers.assert_hydra_equal_to_offline(
+  image_modified, _ = test_helpers.assert_hydra_equal_to_offline(
       stage,
       output_prefix='test_modify_curve_transform_only',
-      atol=0.1,
+      atol=0.05,
       engine=engine,
+  )
+  assert not np.allclose(
+      image_modified[..., :3], image_original[..., :3], atol=0.01
   )

--- a/usd_mitsuba/translator.py
+++ b/usd_mitsuba/translator.py
@@ -119,12 +119,14 @@ def _create_empty_mitsuba_curve(curve_type: str, bsdf: Any) -> mi.Object:
 def _convert_curves(
     prim: Usd.Prim,
     time: Usd.TimeCode = Usd.TimeCode.Default(),
-) -> mi.Object | None:
+) -> mi.Object:
   """Handles a curves prim and returns the Mitsuba curve object."""
   curve_prim = UsdGeom.Curves(prim)
   widths = curve_prim.GetWidthsAttr().Get(time)
   if widths is None or len(widths) == 0:
-    return None
+    raise ValueError(
+        f"Curves prim '{prim.GetPath()}' is missing widths attribute."
+    )
 
   curve_points = np.array(
       curve_prim.GetPointsAttr().Get(time), dtype=np.float32
@@ -291,6 +293,5 @@ def convert_to_mitsuba(
     ):
       mi_scene_dict[mi_id] = light.convert_light(prim, time)
     elif prim.IsA(UsdGeom.Curves):
-      if (curve_obj := _convert_curves(prim, time)) is not None:
-        mi_scene_dict[mi_id] = curve_obj
+      mi_scene_dict[mi_id] = _convert_curves(prim, time)
   return mi_scene_dict

--- a/usd_mitsuba/translator.py
+++ b/usd_mitsuba/translator.py
@@ -119,23 +119,33 @@ def _create_empty_mitsuba_curve(curve_type: str, bsdf: Any) -> mi.Object:
 def _convert_curves(
     prim: Usd.Prim,
     time: Usd.TimeCode = Usd.TimeCode.Default(),
-) -> mi.Object:
+) -> mi.Object | None:
   """Handles a curves prim and returns the Mitsuba curve object."""
   curve_prim = UsdGeom.Curves(prim)
-  curve_points = np.array(curve_prim.GetPointsAttr().Get(time))
-  bsdf, _, _ = material.convert_material(prim)
   widths = curve_prim.GetWidthsAttr().Get(time)
-  if widths is not None:
-    widths = np.array(widths)
-    if widths.ndim == 0 or widths.size == 1:
-      radius = np.full((curve_points.shape[0], 1), widths.item() * 0.5)
-    elif widths.size == curve_points.shape[0]:
-      radius = widths.reshape(-1, 1) * 0.5
-    else:
-      # Fallback to mean for other interpolations (e.g., uniform per curve)
-      radius = np.full((curve_points.shape[0], 1), np.mean(widths) * 0.5)
+  if widths is None or len(widths) == 0:
+    return None
+
+  curve_points = np.array(
+      curve_prim.GetPointsAttr().Get(time), dtype=np.float32
+  )
+  world_mat = np.array(
+      curve_prim.ComputeLocalToWorldTransform(time), dtype=np.float32
+  )
+  ones = np.ones((curve_points.shape[0], 1), dtype=np.float32)
+  pts_homog = np.hstack([curve_points, ones])
+  pts_world_homog = pts_homog @ world_mat
+  curve_points = pts_world_homog[:, :3] / pts_world_homog[:, 3:4]
+  bsdf, _, _ = material.convert_material(prim)
+
+  widths = np.array(widths)
+  if widths.ndim == 0 or widths.size == 1:
+    radius = np.full((curve_points.shape[0], 1), widths.item() * 0.5)
+  elif widths.size == curve_points.shape[0]:
+    radius = widths.reshape(-1, 1) * 0.5
   else:
-    radius = np.full((curve_points.shape[0], 1), 0.01)
+    # Fallback to mean for other interpolations (e.g., uniform per curve)
+    radius = np.full((curve_points.shape[0], 1), np.mean(widths) * 0.5)
   curve_points = np.hstack([curve_points, radius])
 
   curve_point_counts = np.array(
@@ -281,5 +291,6 @@ def convert_to_mitsuba(
     ):
       mi_scene_dict[mi_id] = light.convert_light(prim, time)
     elif prim.IsA(UsdGeom.Curves):
-      mi_scene_dict[mi_id] = _convert_curves(prim, time)
+      if (curve_obj := _convert_curves(prim, time)) is not None:
+        mi_scene_dict[mi_id] = curve_obj
   return mi_scene_dict


### PR DESCRIPTION
Fix USD curve rendering issues in hdMitsuba:

- Store world transform in CurveSpec and bake into control points during BuildCurves.
- Add unit test test_curve_transform verifying parity with usd_mitsuba.